### PR TITLE
Fix crash in rake apn:notifications:deliver when not using "default app"

### DIFF
--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -31,8 +31,8 @@ class APN::App < APN::Base
     apps.each do |app|
       app.send_notifications
     end
-    global_cert = File.read(configatron.apn.cert)
-    if global_cert
+    if !configatron.apn.cert.blank?
+      global_cert = File.read(configatron.apn.cert)
       send_notifications_for_cert(global_cert, nil)
     end
   end
@@ -123,8 +123,8 @@ class APN::App < APN::Base
     apps.each do |app|
       app.process_devices
     end
-    global_cert = File.read(configatron.apn.cert)
-    if global_cert
+    if !configatron.apn.cert.blank?
+      global_cert = File.read(configatron.apn.cert)
       APN::App.process_devices_for_cert(global_cert)
     end
   end


### PR DESCRIPTION
Current code does an unprotected File.read on the configatron cert, which means it crashes if the file isn't there and it crashes if you set it to null. 

Doesn't look like all the tests were passing before my changes. I see the same two failures before and after.

/rdj
