### PR TITLE
suggested chang to fix issue #20 (https://github.com/PRX/apn_on_rails/issues#issue/20)

### DIFF
--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -46,7 +46,7 @@ class APN::App < APN::Base
       end
       begin
         APN::Connection.open_for_delivery({:cert => the_cert}) do |conn, sock|
-          notifications = APN::Notification.find(:all, :conditions => conditions, :joins => " INNER JOIN apn_devices ON apn_devices.id = apn_notifications.device_id")
+          notifications = APN::Notification.find(:all, :select => "apn_notifications.*", :conditions => conditions, :joins => " INNER JOIN apn_devices ON apn_devices.id = apn_notifications.device_id")
           notifications.each do |noty|
             conn.write(noty.message_for_sending)
             noty.sent_at = Time.now

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -40,18 +40,17 @@ class APN::App < APN::Base
   def self.send_notifications_for_cert(the_cert, app_id)
     # unless self.unsent_notifications.nil? || self.unsent_notifications.empty?
       if (app_id == nil)
-        conditions = "app_id is null"
+        conditions = "app_id is null and sent_at is null"
       else 
-        conditions = ["app_id = ?", app_id]
+        conditions = ["app_id = ? and sent_at is null", app_id]
       end
       begin
         APN::Connection.open_for_delivery({:cert => the_cert}) do |conn, sock|
-          APN::Device.find_each(:conditions => conditions) do |dev|
-            dev.unsent_notifications.each do |noty|
-              conn.write(noty.message_for_sending)
-              noty.sent_at = Time.now
-              noty.save
-            end
+          notifications = APN::Notification.find(:all, :conditions => conditions, :joins => " INNER JOIN apn_devices ON apn_devices.id = apn_notifications.device_id")
+          notifications.each do |noty|
+            conn.write(noty.message_for_sending)
+            noty.sent_at = Time.now
+            noty.save
           end
         end
       rescue Exception => e

--- a/spec/apn_on_rails/app/models/apn/app_spec.rb
+++ b/spec/apn_on_rails/app/models/apn/app_spec.rb
@@ -20,10 +20,7 @@ describe APN::App do
       APN::App.should_receive(:all).once.and_return([app])                 
       app.should_receive(:cert).twice.and_return(app.apn_dev_cert)
       
-      APN::Device.should_receive(:find_each).twice.and_yield(device)
-      
-      device.should_receive(:unsent_notifications).and_return(notifications,[])
-      
+      APN::Notification.should_receive(:find).and_return(notifications, [])
       
       ssl_mock = mock('ssl_mock')
       ssl_mock.should_receive(:write).with('message-0')
@@ -52,8 +49,7 @@ describe APN::App do
          notify.should_receive(:save)
        end  
    
-       APN::Device.should_receive(:find_each).and_yield(device)
-       device.should_receive(:unsent_notifications).and_return(notifications)
+       APN::Notification.should_receive(:find).and_return(notifications)
   
        ssl_mock = mock('ssl_mock')
        ssl_mock.should_receive(:write).with('message-0')


### PR DESCRIPTION
As suggested, the code now uses only one query (rather than a query per device) to get all notifications. I have tested the code only locally, so please review carefully ..
