### PR TITLE
log_connection_exception should be a class method

### DIFF
--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -144,7 +144,7 @@ class APN::App < APN::Base
   
   
   protected
-  def log_connection_exception(ex)
+  def self.log_connection_exception(ex)
     puts ex.message
   end
     


### PR DESCRIPTION
log_connection_exception is only called from within one class method. In addition, it fails when it is called because no self.log_connection_exception exists.
