### PR TITLE
Updated instructions for rails 3 generators

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -171,7 +171,7 @@ h3. Upgrade Notes:
 If you are upgrading to a new version of APN on Rails you should always run:
 
 <pre><code>
-  $ ruby script/rails generate apn_migrations
+ruby script/rails generate apn_on_rails:install
 </pre></code>
 
 That way you ensure you have the latest version of the database tables needed.

--- a/README.textile
+++ b/README.textile
@@ -144,7 +144,7 @@ APN on Rails has the following default configurations that you change for your s
 To generate the files that will be used here, run 
 
 <pre><code>
-script/rails generate configatron:install`
+script/rails generate configatron:install
 </pre></code>
 
 Then customize the config/configatron files that were generated to your settings.

--- a/README.textile
+++ b/README.textile
@@ -136,8 +136,10 @@ Now, to create the tables you need for APN on Rails, run the following task:
 </pre></code>
 
 APN on Rails uses the Configatron gem, http://github.com/markbates/configatron/tree/master, 
-to configure itself. (With the change to multi-app support, the certifications are stored in the 
-database rather than in the config directory, however, it is still possible to use the default "app" and the certificates
+to configure itself. With the change to multi-app support, the certifications are stored in the 
+database rather than in the config directory.
+
+However, it is still possible to use the default "app" and the certificates
 stored in the config directory.  For this setup, the following configurations apply.)
 APN on Rails has the following default configurations that you change for your setup.  
 

--- a/README.textile
+++ b/README.textile
@@ -139,8 +139,10 @@ APN on Rails uses the Configatron gem, http://github.com/markbates/configatron/t
 to configure itself. (With the change to multi-app support, the certifications are stored in the 
 database rather than in the config directory, however, it is still possible to use the default "app" and the certificates
 stored in the config directory.  For this setup, the following configurations apply.)
-APN on Rails has the following default configurations that you change as you
-see fit:
+APN on Rails has the following default configurations that you change for your setup.  
+
+To generate the files that will be used here, run `script/rails generate configatron:install`
+Then customize the config/configatron files that were generated to your settings.
 
 <pre><code>
   # development (delivery):

--- a/README.textile
+++ b/README.textile
@@ -141,7 +141,12 @@ database rather than in the config directory, however, it is still possible to u
 stored in the config directory.  For this setup, the following configurations apply.)
 APN on Rails has the following default configurations that you change for your setup.  
 
-To generate the files that will be used here, run `script/rails generate configatron:install`
+To generate the files that will be used here, run 
+
+<pre><code>
+script/rails generate configatron:install`
+</pre></code>
+
 Then customize the config/configatron files that were generated to your settings.
 
 <pre><code>

--- a/README.textile
+++ b/README.textile
@@ -123,10 +123,16 @@ Rake tasks that ship with APN on Rails:
   end
 </pre></code>
 
+You now need to run the APN generator to create the migration files.
+
+<pre><code>
+ruby script/rails generate apn_on_rails:install
+</pre></code>
+
 Now, to create the tables you need for APN on Rails, run the following task:
 
 <pre><code>
-  $ ruby script/generate apn_migrations
+  $  rake db:migrate
 </pre></code>
 
 APN on Rails uses the Configatron gem, http://github.com/markbates/configatron/tree/master, 

--- a/README.textile
+++ b/README.textile
@@ -165,7 +165,7 @@ h3. Upgrade Notes:
 If you are upgrading to a new version of APN on Rails you should always run:
 
 <pre><code>
-  $ ruby script/generate apn_migrations
+  $ ruby script/rails generate apn_migrations
 </pre></code>
 
 That way you ensure you have the latest version of the database tables needed.


### PR DESCRIPTION
Update to reflect change from rails 2 syntax to Rails 3 syntax  
i.e.  
$ ruby script/generate apn_migrations  
 to  
$ ruby script/rails generate apn_migrations  
