### PR TITLE
alerts can be hashes as well

### DIFF
--- a/lib/apn_on_rails/app/models/apn/notification.rb
+++ b/lib/apn_on_rails/app/models/apn/notification.rb
@@ -1,6 +1,8 @@
-# Represents the message you wish to send. 
+# encoding: utf-8
+
+# Represents the message you wish to send.
 # An APN::Notification belongs to an APN::Device.
-# 
+#
 # Example:
 #   apn = APN::Notification.new
 #   apn.badge = 5
@@ -8,10 +10,10 @@
 #   apn.alert = 'Hello!'
 #   apn.device = APN::Device.find(1)
 #   apn.save
-# 
+#
 # To deliver call the following method:
 #   APN::Notification.send_notifications
-# 
+#
 # As each APN::Notification is sent the <tt>sent_at</tt> column will be timestamped,
 # so as to not be sent again.
 class APN::Notification < APN::Base
@@ -19,23 +21,22 @@ class APN::Notification < APN::Base
   extend ::ActionView::Helpers::TextHelper
   serialize :custom_properties
   serialize :alert
-  
+
   belongs_to :device, :class_name => 'APN::Device'
   has_one    :app,    :class_name => 'APN::App', :through => :device
-  
+
   # Stores the text alert message you want to send to the device.
-  # 
+  #
   # If the message is over 150 characters long it will get truncated
   # to 150 characters with a <tt>...</tt>
   def alert=(message)
-    if !message.blank? && message.size > 145
-      message = truncate(message, :length => 145)
-    end
-    write_attribute('alert', message)
+    msg = message.force_encoding("UTF-8")
+    msg = "#{msg.byteslice(0, 147)}..." if !msg.blank? && msg.bytesize > 150
+    write_attribute('alert', msg)
   end
-  
+
   # Creates a Hash that will be the payload of an APN.
-  # 
+  #
   # Example:
   #   apn = APN::Notification.new
   #   apn.badge = 5
@@ -43,14 +44,14 @@ class APN::Notification < APN::Base
   #   apn.alert = 'Hello!'
   #   apn.apple_hash # => {"aps" => {"badge" => 5, "sound" => "my_sound.aiff", "alert" => "Hello!"}}
   #
-  # Example 2: 
+  # Example 2:
   #   apn = APN::Notification.new
   #   apn.badge = 0
   #   apn.sound = true
   #   apn.custom_properties = {"typ" => 1}
   #   apn.apple_hash # => {"aps" => {"badge" => 0, "sound" => "1.aiff"}, "typ" => "1"}
-  # 
-  # Example 3: 
+  #
+  # Example 3:
   #   apn = APN::Notification.new
   #   apn.badge = 0
   #   apn.sound = true
@@ -65,9 +66,9 @@ class APN::Notification < APN::Base
         result['aps']['alert'] = {}
         self.alert.each do |key,value|
           result['aps']['alert']["#{key}"] = "#{value}"
-        end 
+        end
       else
-        result['aps']['alert'] = self.alert 
+        result['aps']['alert'] = self.alert
       end
     end
     result['aps']['badge'] = self.badge.to_i if self.badge
@@ -82,9 +83,9 @@ class APN::Notification < APN::Base
     end
     result
   end
-  
+
   # Creates the JSON string required for an APN message.
-  # 
+  #
   # Example:
   #   apn = APN::Notification.new
   #   apn.badge = 5
@@ -94,7 +95,7 @@ class APN::Notification < APN::Base
   def to_apple_json
     self.apple_hash.to_json
   end
-  
+
   # Creates the binary message needed to send to Apple.
   def message_for_sending
     json = self.to_apple_json
@@ -102,10 +103,10 @@ class APN::Notification < APN::Base
     raise APN::Errors::ExceededMessageSizeError.new("#{message} #{message.size.to_i}") if message.size.to_i > 256
     message
   end
-  
+
   def self.send_notifications
     ActiveSupport::Deprecation.warn("The method APN::Notification.send_notifications is deprecated.  Use APN::App.send_notifications instead.")
     APN::App.send_notifications
   end
-  
+
 end # APN::Notification

--- a/lib/apn_on_rails/app/models/apn/notification.rb
+++ b/lib/apn_on_rails/app/models/apn/notification.rb
@@ -30,9 +30,11 @@ class APN::Notification < APN::Base
   # If the message is over 150 characters long it will get truncated
   # to 150 characters with a <tt>...</tt>
   def alert=(message)
-    msg = message.force_encoding("UTF-8")
-    msg = "#{msg.byteslice(0, 147)}..." if !msg.blank? && msg.bytesize > 150
-    write_attribute('alert', msg)
+    unless message.blank?
+      message = message.force_encoding("UTF-8")
+      message = "#{message.byteslice(0, 147)}..." if message.bytesize > 150
+    end
+    write_attribute('alert', message)
   end
 
   # Creates a Hash that will be the payload of an APN.

--- a/lib/apn_on_rails/app/models/apn/notification.rb
+++ b/lib/apn_on_rails/app/models/apn/notification.rb
@@ -18,6 +18,7 @@ class APN::Notification < APN::Base
   include ::ActionView::Helpers::TextHelper
   extend ::ActionView::Helpers::TextHelper
   serialize :custom_properties
+  serialize :alert
   
   belongs_to :device, :class_name => 'APN::Device'
   has_one    :app,    :class_name => 'APN::App', :through => :device
@@ -48,10 +49,27 @@ class APN::Notification < APN::Base
   #   apn.sound = true
   #   apn.custom_properties = {"typ" => 1}
   #   apn.apple_hash # => {"aps" => {"badge" => 0, "sound" => "1.aiff"}, "typ" => "1"}
+  # 
+  # Example 3: 
+  #   apn = APN::Notification.new
+  #   apn.badge = 0
+  #   apn.sound = true
+  #   apn.custom_properties = {"typ" => 1}
+  #   apn.apple_hash # => {"aps" => {"badge" => 0, "sound" => "1.aiff", "alert" => {"body" => "test", "action-loc-key" => "test-loc-key"}}, "typ" => "1"}
+
   def apple_hash
     result = {}
     result['aps'] = {}
-    result['aps']['alert'] = self.alert if self.alert
+    if self.alert
+      if self.alert.kind_of?(Hash)
+        result['aps']['alert'] = {}
+        self.alert.each do |key,value|
+          result['aps']['alert']["#{key}"] = "#{value}"
+        end 
+      else
+        result['aps']['alert'] = self.alert 
+      end
+    end
     result['aps']['badge'] = self.badge.to_i if self.badge
     if self.sound
       result['aps']['sound'] = self.sound if self.sound.is_a? String

--- a/lib/apn_on_rails/app/models/apn/notification.rb
+++ b/lib/apn_on_rails/app/models/apn/notification.rb
@@ -28,8 +28,8 @@ class APN::Notification < APN::Base
   # If the message is over 150 characters long it will get truncated
   # to 150 characters with a <tt>...</tt>
   def alert=(message)
-    if !message.blank? && message.size > 150
-      message = truncate(message, :length => 150)
+    if !message.blank? && message.size > 145
+      message = truncate(message, :length => 145)
     end
     write_attribute('alert', message)
   end

--- a/lib/apn_on_rails/app/models/apn/notification.rb
+++ b/lib/apn_on_rails/app/models/apn/notification.rb
@@ -99,7 +99,7 @@ class APN::Notification < APN::Base
   def message_for_sending
     json = self.to_apple_json
     message = "\0\0 #{self.device.to_hexa}\0#{json.length.chr}#{json}"
-    raise APN::Errors::ExceededMessageSizeError.new(message) if message.size.to_i > 256
+    raise APN::Errors::ExceededMessageSizeError.new("#{message} #{message.size.to_i}") if message.size.to_i > 256
     message
   end
   


### PR DESCRIPTION
Hi,

according to: http://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1

The alert itself can be a hash as well. Needed this, done it, tested with an IOS App.

Regards,

ABA
