### PR TITLE
Only update noty.sent_at on successful write

### DIFF
--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -48,9 +48,18 @@ class APN::App < APN::Base
         APN::Connection.open_for_delivery({:cert => the_cert}) do |conn, sock|
           APN::Device.find_each(:conditions => conditions) do |dev|
             dev.unsent_notifications.each do |noty|
-              conn.write(noty.message_for_sending)
-              noty.sent_at = Time.now
-              noty.save
+
+              begin
+                result = conn.write(noty.message_for_sending)
+                unless result.nil?
+                  noty.sent_at = Time.now
+                  noty.save
+                else
+                  raise Error, "Connection error for notification #{noty.id}"
+                end
+                result = nil
+              rescue
+              end
             end
           end
         end


### PR DESCRIPTION
Hi, 

Thanks for extending and keeping this gem up-to-date.

Would you please accept this pull request that only updates noty.sent_at on a successful write?

I ran into an issue where notifications were marked as sent when they were not.

Cheers, Barce
