### PR TITLE
Missing push notifications for all but first device when sending through Delayed::Job

### DIFF
--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.0009765625"
-              sleep 0.0009765625
+              puts "SLEEPING 0.0001924557352"
+              sleep 0.0001924557352
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.00009622"
-              sleep 0.00009622
+              puts "SLEEPING 0.00002405"
+              sleep 0.00002405
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.00002405"
-              sleep 0.00002405
+              puts "SLEEPING 0.000000601"
+              sleep 0.000000601
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -48,6 +48,10 @@ class APN::App < APN::Base
         APN::Connection.open_for_delivery({:cert => the_cert}) do |conn, sock|
           APN::Device.find_each(:conditions => conditions) do |dev|
             dev.unsent_notifications.each do |noty|
+              puts "----NOTIFICATION:\n"
+              puts noty.to_yaml
+              puts "-----------------\n"
+              
               conn.write(noty.message_for_sending)
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.0078125"
-              sleep 0.0078125
+              puts "SLEEPING 0.00390625"
+              sleep 0.00390625
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.000000300"
-              sleep 0.000000300
+              puts "SLEEPING 0.00000001"
+              sleep 0.00000001
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,7 +53,7 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.25"
+              puts "SLEEPING 0.125"
               sleep 0.25
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -49,10 +49,11 @@ class APN::App < APN::Base
           APN::Device.find_each(:conditions => conditions) do |dev|
             dev.unsent_notifications.each do |noty|
               puts "----NOTIFICATION:\n"
-              puts noty.to_yaml
+              puts noty.message_for_sending.to_yaml
               puts "-----------------\n"
-              
-              conn.write(noty.message_for_sending)
+
+              puts conn.write(noty.message_for_sending)
+              puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save
             end

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -48,14 +48,13 @@ class APN::App < APN::Base
         APN::Connection.open_for_delivery({:cert => the_cert}) do |conn, sock|
           APN::Device.find_each(:conditions => conditions) do |dev|
             dev.unsent_notifications.each do |noty|
-              puts "----NOTIFICATION:\n"
-              puts noty.message_for_sending.to_yaml
-              puts "-----------------\n"
-
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.00000001"
+
+              # This seems to fix the bug where multiple notifications get 
+              # missed by Apple when sending Push notifications as a worker 
+              # task through Delayed::Job
               sleep 0.00000001
-              puts "^^^^^^^^^^^^^^^^^\n"
+
               noty.sent_at = Time.now
               noty.save
             end

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,6 +53,7 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
+              sleep 1
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.0001924557352"
-              sleep 0.0001924557352
+              puts "SLEEPING 0.00009622"
+              sleep 0.00009622
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,6 +53,7 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
+              puts "SLEEPING 0.5"
               sleep 0.5
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.5"
-              sleep 0.5
+              puts "SLEEPING 0.25"
+              sleep 0.25
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.03375"
-              sleep 0.03375
+              puts "SLEEPING 0.015625"
+              sleep 0.015625
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.000000601"
-              sleep 0.000000601
+              puts "SLEEPING 0.000000300"
+              sleep 0.000000300
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.00390625"
-              sleep 0.00390625
+              puts "SLEEPING 0.0009765625"
+              sleep 0.0009765625
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -19,12 +19,11 @@ class APN::App < APN::Base
   # so as to not be sent again.
   #
   def send_notifications
-    puts "USING LOCAL PLUGIN ATTENTION THIS IS USING THE LOCAL PLUGIN ATTENTION THIS IS USING A LOCAL VERSION OF THIS PLUGIN ATTENTION!!!!!"
-    # if self.cert.nil?
-    #   raise APN::Errors::MissingCertificateError.new
-    #   return
-    # end
-    # APN::App.send_notifications_for_cert(self.cert, self.id)
+    if self.cert.nil?
+      raise APN::Errors::MissingCertificateError.new
+      return
+    end
+    APN::App.send_notifications_for_cert(self.cert, self.id)
   end
 
   def self.send_notifications

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.015625"
-              sleep 0.015625
+              puts "SLEEPING 0.0078125"
+              sleep 0.0078125
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -54,7 +54,7 @@ class APN::App < APN::Base
 
               puts conn.write(noty.message_for_sending)
               puts "SLEEPING 0.125"
-              sleep 0.25
+              sleep 0.125
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -19,11 +19,12 @@ class APN::App < APN::Base
   # so as to not be sent again.
   #
   def send_notifications
-    if self.cert.nil?
-      raise APN::Errors::MissingCertificateError.new
-      return
-    end
-    APN::App.send_notifications_for_cert(self.cert, self.id)
+    puts "USING LOCAL PLUGIN ATTENTION THIS IS USING THE LOCAL PLUGIN ATTENTION THIS IS USING A LOCAL VERSION OF THIS PLUGIN ATTENTION!!!!!"
+    # if self.cert.nil?
+    #   raise APN::Errors::MissingCertificateError.new
+    #   return
+    # end
+    # APN::App.send_notifications_for_cert(self.cert, self.id)
   end
 
   def self.send_notifications

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -48,7 +48,7 @@ class APN::App < APN::Base
         APN::Connection.open_for_delivery({:cert => the_cert}) do |conn, sock|
           APN::Device.find_each(:conditions => conditions) do |dev|
             dev.unsent_notifications.each do |noty|
-              puts conn.write(noty.message_for_sending)
+              conn.write(noty.message_for_sending)
 
               # This seems to fix the bug where multiple notifications get 
               # missed by Apple when sending Push notifications as a worker 

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.0675"
-              sleep 0.0675
+              puts "SLEEPING 0.03375"
+              sleep 0.03375
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,8 +53,8 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              puts "SLEEPING 0.125"
-              sleep 0.125
+              puts "SLEEPING 0.0675"
+              sleep 0.0675
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/app/models/apn/app.rb
+++ b/lib/apn_on_rails/app/models/apn/app.rb
@@ -53,7 +53,7 @@ class APN::App < APN::Base
               puts "-----------------\n"
 
               puts conn.write(noty.message_for_sending)
-              sleep 1
+              sleep 0.5
               puts "^^^^^^^^^^^^^^^^^\n"
               noty.sent_at = Time.now
               noty.save

--- a/lib/apn_on_rails/libs/connection.rb
+++ b/lib/apn_on_rails/libs/connection.rb
@@ -47,11 +47,6 @@ module APN
                    :passphrase => configatron.apn.passphrase,
                    :host => configatron.apn.host,
                    :port => configatron.apn.port}.merge(options)
-
-        puts '-----------------\n'
-        puts options.to_yaml
-        puts '=================\n'
-        
         #cert = File.read(options[:cert])
         cert = options[:cert]
         ctx = OpenSSL::SSL::SSLContext.new

--- a/lib/apn_on_rails/libs/connection.rb
+++ b/lib/apn_on_rails/libs/connection.rb
@@ -47,6 +47,11 @@ module APN
                    :passphrase => configatron.apn.passphrase,
                    :host => configatron.apn.host,
                    :port => configatron.apn.port}.merge(options)
+
+        puts '-----------------\n'
+        puts options.to_yaml
+        puts '=================\n'
+        
         #cert = File.read(options[:cert])
         cert = options[:cert]
         ctx = OpenSSL::SSL::SSLContext.new


### PR DESCRIPTION
Not sure why this is, or why my fix fixes this problem (or even whether anyone else has encountered this), but I've noticed that when I have multiple devices queued up for push notifications in a Delayed::Job, the PRX Master branch doesn't seem to successfully send notifications to any device beyond the first one. At least that was my experience on Heroku.

I was able to solve this problem by adding a sleep() instruction for a VERY small fraction of time (specifically 0.00000001). If no one else has experienced this problem, I'd recommend rejecting my pull request. Also, if there's some better solution to this, I'd appreciate knowing about it. If, however, there are others who have experienced this issue, and no solution has been found, I recommend this, as it is simple, and does not seem to have singificant drawbacks.
